### PR TITLE
Feature/total-coin-balance-calculation

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/index.ts
+++ b/packages/bitcore-node/src/providers/chain-state/index.ts
@@ -62,6 +62,10 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return this.get(params).getStats(params);
   }
 
+  getCoinCalculation(params: CSP.GetCoinCalculation) {
+    return this.get(params).getCoinCalculation(params);
+  }
+
   getTransaction(params: CSP.StreamTransactionParams) {
     return this.get(params).getTransaction(params);
   }
@@ -118,7 +122,7 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return this.get(params).getCoinsForTx(params);
   }
 
-  async getLatestTransactions(params: CSP.GetLatestTransactionsParams){
+  async getLatestTransactions(params: CSP.GetLatestTransactionsParams) {
     return this.get(params).getLatestTrnasactions(params);
   }
 

--- a/packages/bitcore-node/src/routes/api/stats.ts
+++ b/packages/bitcore-node/src/routes/api/stats.ts
@@ -2,10 +2,20 @@ import { Request, Response } from 'express';
 import { ChainStateProvider } from '../../providers/chain-state';
 const router = require('express').Router({ mergeParams: true });
 
-router.get('/', async function(req: Request, res: Response) {
+router.get('/', async function (req: Request, res: Response) {
   try {
     const { chain, network } = req.params;
-    const result = await ChainStateProvider.getStats({ chain, network});
+    const result = await ChainStateProvider.getStats({ chain, network });
+    return res.send(result);
+  } catch (err) {
+    return res.status(500).send(err);
+  }
+});
+
+router.get('/total-coin', async function (req: Request, res: Response) {
+  try {
+    const { chain, network } = req.params;
+    const result = await ChainStateProvider.getCoinCalculation({ chain, network });
     return res.send(result);
   } catch (err) {
     return res.status(500).send(err);
@@ -14,7 +24,7 @@ router.get('/', async function(req: Request, res: Response) {
 
 let cacheThroughTruncatedDate;
 let cachedDailyTransactions;
-router.get('/daily-transactions', async function(req: Request, res: Response) {
+router.get('/daily-transactions', async function (req: Request, res: Response) {
   const { chain, network } = req.params;
   const truncatedUTC = new Date().toISOString().split('T')[0];
   if (truncatedUTC === cacheThroughTruncatedDate) {

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -157,7 +157,7 @@ export declare namespace CSP {
     getAuthhead(params: StreamTransactionParams): Promise<AuthheadJSON | undefined>;
     getDailyTransactions(params: { chain: string; network: string }): Promise<DailyTransactionsJSON>;
     getStats(params: GetStatsParams): Promise<any>;
-    getCoinCalculation(params: GetCoinCalculation): Promise<any>;
+    getCoinCalculation(params: GetCoinCalculation): Promise<{ total: number }>;
     getTransaction(params: StreamTransactionParams): Promise<TransactionJSON | string | undefined>;
     streamWalletAddresses(params: StreamWalletAddressesParams): any;
     walletCheck(params: WalletCheckParams): any;

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -129,6 +129,8 @@ export declare namespace CSP {
     res: Response;
   };
 
+  export type GetCoinCalculation = ChainNetwork;
+
   export type Provider<T> = { get(params: { chain: string }): T };
   export type ChainStateProvider = Provider<IChainStateService> & IChainStateService;
   export interface IChainStateService {
@@ -155,6 +157,7 @@ export declare namespace CSP {
     getAuthhead(params: StreamTransactionParams): Promise<AuthheadJSON | undefined>;
     getDailyTransactions(params: { chain: string; network: string }): Promise<DailyTransactionsJSON>;
     getStats(params: GetStatsParams): Promise<any>;
+    getCoinCalculation(params: GetCoinCalculation): Promise<any>;
     getTransaction(params: StreamTransactionParams): Promise<TransactionJSON | string | undefined>;
     streamWalletAddresses(params: StreamWalletAddressesParams): any;
     walletCheck(params: WalletCheckParams): any;


### PR DESCRIPTION
- Add a new endpoint on bitcore-node `/stats/total-coin` which fetch total coin balance for a given pair of chain and network.