### PR TITLE
"sat" replaced by "fi

### DIFF
--- a/packages/insight-previous/src/pages/transaction/transaction.html
+++ b/packages/insight-previous/src/pages/transaction/transaction.html
@@ -44,7 +44,7 @@
           <ion-item *ngIf="tx.fee >= 0">
             Fee Rate
             <ion-note item-end>
-              {{ (tx.fee / tx.size) | number:'1.0-2' }} sats/byte
+              {{ (tx.fee / tx.size) | number:'1.0-2' }} fi/byte
             </ion-note>
           </ion-item>
           <ion-item>


### PR DESCRIPTION
For Bitcoin, fees are expressed in "sat". For DeFiChain in "fi". Therefore, I recommend changing the display to "fi".

<img width="252" alt="Bildschirmfoto 2021-03-12 um 00 11 56" src="https://user-images.githubusercontent.com/65536965/110867748-91229e80-82c7-11eb-86ae-0b0df215b913.png">

@thedoublejay @izzycsy 