### PR TITLE
Fix/anchor conf spell issue

### DIFF
--- a/packages/bitcore-p2p-dfi/lib/messages/builder.js
+++ b/packages/bitcore-p2p-dfi/lib/messages/builder.js
@@ -60,7 +60,7 @@ function builder(options) {
       mempool: 'MemPool',
       getaddr: 'GetAddr',
       anchorauth: 'AnchorAuth',
-      anchorcnf: 'AnchorConformation',
+      anchorconf: 'AnchorConformation',
       getauths: 'GetAuths',
     },
     commands: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- fix spelling of anchorcnf to anchorconf causing error to bitcore-node

#### Additional comments?:
