### PR TITLE
Reduce number of blocks in home page

### DIFF
--- a/packages/insight-previous/src/providers/default/default.ts
+++ b/packages/insight-previous/src/providers/default/default.ts
@@ -17,7 +17,7 @@ export class DefaultProvider {
     //@ts-ignore
     '%NETWORK%': process.env.NETWORK || 'mainnet',
     //@ts-ignore
-    '%NUM_BLOCKS%': process.env.NUM_BLOCKS || '20',
+    '%NUM_BLOCKS%': process.env.NUM_BLOCKS || '10',
     //@ts-ignore
     '%NUM_TRX_BLOCKS%': process.env.NUM_TRX_BLOCKS || '10',
     //@ts-ignore


### PR DESCRIPTION
Resets the number of blocks as it were before commit [1].

The referred commit kept the page layout consistent during the absence of tx blocks. Now that both tx and blocks are present, having them both in smaller equal blocks avoid scrolling down and provides better visibility on first view.  

--
[1] https://github.com/DeFiCh/defi-explorer/commit/454e33665e5afb8a389e783759ab0fd8cc6b0fae#diff-9ba337702a6f8099c1d2229be67f3cb7d11f7fb83e41e0335081ea8da58d4621

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

#### Additional comments?:
